### PR TITLE
Updates to tune the experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Local .terraform directories
 **/.terraform/*
+**/terraform.tfvars
+**/.terraform.lock.hcl
 
 # .tfstate files
 *.tfstate

--- a/examples/simple-sso/main.tf
+++ b/examples/simple-sso/main.tf
@@ -15,8 +15,25 @@ module "pingone_environment" {
 
   target_environment_name = var.target_environment_name
 
-  organization_id      = var.organization_id
   license_name         = var.license_name
-  admin_environment_id = var.admin_environment_id
-  admin_user_id        = var.admin_environment_user_id
+  admin_user_id_list   = data.pingone_users.admin_users.ids
+}
+
+###############################################################################
+# Supporting User selection
+###############################################################################
+
+data "pingone_environment" "administrators" {
+  name = "Administrators"
+}
+
+data "pingone_users" "admin_users" {
+  environment_id = data.pingone_environment.administrators.id
+
+  data_filter {
+    name = "email"
+    values = [
+      "myuser@bxretail.org"
+    ]
+  }
 }

--- a/examples/simple-sso/variables.tf
+++ b/examples/simple-sso/variables.tf
@@ -4,10 +4,6 @@ variable "region" {
   type        = string
 }
 
-variable "organization_id" {
-  description = "PingOne Region"
-  type        = string
-}
 variable "license_name" {
   description = "PingOne License Name"
   type        = string
@@ -29,8 +25,3 @@ variable "admin_environment_client_secret" {
   description = "PingOne Adminstrators Client Secret"
   type        = string
 }
-variable "admin_environment_user_id" {
-  description = "PingOne Adminstrators User ID"
-  type        = string
-}
-

--- a/examples/simple-sso/versions.tf
+++ b/examples/simple-sso/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     pingone = {
       source  = "pingidentity/pingone"
-      version = ">= 0.6.0"
+      version = ">= 0.6.1"
     }
     davinci = {
       source  = "samir-gandhi/davinci"

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ data "pingone_licenses" "org_licenses" {
 resource "pingone_environment" "env_instance" {
   name        = var.target_environment_name
   description = var.target_environment_description
-  type        = "SANDBOX"
+  type        = var.target_environment_production_type ? "PRODUCTION" : "SANDBOX"
   license_id  = var.license_id != null && var.license_id != "" ? var.license_id : data.pingone_licenses.org_licenses[0].ids[0]
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -1,17 +1,28 @@
-
+#########################################################################
+# PineOne Admin Environment
+#########################################################################
+data "pingone_environment" "administrators" {
+  name = try(var.admin_environment_name, "Administrators")
+}
 
 #########################################################################
 # PingOne License ID
 #########################################################################
 data "pingone_licenses" "org_licenses" {
-  organization_id = var.organization_id
+  count = var.license_name != null && var.license_name != "" ? 1 : 0
+
+  organization_id = var.organization_id != null && var.organization_id != "" ? var.organization_id : data.pingone_environment.administrators.organization_id
 
   data_filter {
     name   = "name"
     values = [var.license_name]
   }
-}
 
+  data_filter {
+    name   = "status"
+    values = ["ACTIVE"]
+  }
+}
 
 #########################################################################
 # PineOne Environment
@@ -20,7 +31,14 @@ resource "pingone_environment" "env_instance" {
   name        = var.target_environment_name
   description = var.target_environment_description
   type        = "SANDBOX"
-  license_id  = data.pingone_licenses.org_licenses.ids[0]
+  license_id  = var.license_id != null && var.license_id != "" ? var.license_id : data.pingone_licenses.org_licenses[0].ids[0]
+
+  lifecycle {
+    precondition {
+      condition     = (var.license_id != null && var.license_id != "") || ((var.license_name != null && var.license_name != "") && length(data.pingone_licenses.org_licenses) == 1)
+      error_message = "Ensure one of `license_id` or `license_name` is set.  If using `license_name`, only one license must be returned."
+    }
+  }
 
   default_population {
     name        = "My Population"
@@ -97,17 +115,19 @@ data "pingone_role" "environment_admin" {
 # PingOne Role Assignment
 #########################################################################
 resource "pingone_role_assignment_user" "identity_data_admin_role" {
-  # count                = var.admin_user_id != "" && var.admin_environment_id != "" ? 1 : 0
-  environment_id       = var.admin_environment_id
-  user_id              = var.admin_user_id
+  count = var.admin_user_assign_identity_admin_role && length(var.admin_user_id_list) > 0 ? length(var.admin_user_id_list) : 0
+
+  environment_id       = var.admin_environment_id != null && var.admin_environment_id != "" ? var.admin_environment_id : data.pingone_environment.administrators.id
+  user_id              = var.admin_user_id_list[count.index]
   role_id              = data.pingone_role.identity_data_admin.id
   scope_environment_id = pingone_environment.env_instance.id
 }
 
 resource "pingone_role_assignment_user" "environment_admin_role" {
-  # count                = var.admin_user_id != "" && var.admin_environment_id != "" ? 1 : 0
-  environment_id       = var.admin_environment_id
-  user_id              = var.admin_user_id
+  count = var.admin_user_assign_environment_admin_role && length(var.admin_user_id_list) > 0 ? length(var.admin_user_id_list) : 0
+
+  environment_id       = var.admin_environment_id != null && var.admin_environment_id != "" ? var.admin_environment_id : data.pingone_environment.administrators.id
+  user_id              = var.admin_user_id_list[count.index]
   role_id              = data.pingone_role.environment_admin.id
   scope_environment_id = pingone_environment.env_instance.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,24 +1,50 @@
 
 variable "organization_id" {
-  description = "PingOne Organization ID - Used to obtain license_id"
+  description = "PingOne Organization ID - Used to obtain license_id.  If set, will take precidence over the organization ID found from using the `admin_environment_name` parameter."
   type        = string
+  default     = null
+}
+
+variable "license_id" {
+  description = "PingOne License ID to assign to the environment.  If set, will take precidence over the license ID found from using the `license_name` parameter."
+  type        = string
+  default = null
 }
 
 variable "license_name" {
   description = "PingOne License Name - Used to obtain license_id"
   type        = string
+  default = null
+}
+
+variable "admin_environment_name" {
+  description = "PingOne Admin Environment Name, used to assign admin user role permissions and lookup the current organization ID.  Defaults to `Administrators`."
+  type        = string
+  default     = "Administrators"
 }
 
 variable "admin_environment_id" {
-  description = "PingOne Admin Environment ID"
+  description = "PingOne Admin Environment ID, used to assign admin user role permissions and lookup the current organization ID.  If set, will take precidence over the `admin_environment_name` parameter."
   type        = string
-  default     = ""
+  default     = null
 }
 
-variable "admin_user_id" {
+variable "admin_user_id_list" {
   description = "PingOne Environment Admin User ID"
-  type        = string
-  default     = ""
+  type        = list(string)
+  default     = []
+}
+
+variable "admin_user_assign_identity_admin_role" {
+  description = "Assign the `Identity Data Admin` role to users set in the `admin_user_id_list` parameter."
+  type        = bool
+  default     = true
+}
+
+variable "admin_user_assign_environment_admin_role" {
+  description = "Assign the `Environment Admin` role to users set in the `admin_user_id_list` parameter."
+  type        = bool
+  default     = true
 }
 
 
@@ -31,7 +57,7 @@ variable "target_environment_name" {
 variable "target_environment_description" {
   description = "PingOne Target Environment Description"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "create_authorize" {

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,12 @@ variable "target_environment_description" {
   default     = null
 }
 
+variable "target_environment_production_type" {
+  description = "Enables the environment as a Production environment.  This enables features that prevent accidental deletion of an environment and associated data."
+  type = bool
+  default = false
+}
+
 variable "create_authorize" {
   description = "Create the PingOne Authorize Service"
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     pingone = {
       source  = "pingidentity/pingone"
-      version = ">= 0.6.0"
+      version = ">= 0.6.1"
     }
   }
 }


### PR DESCRIPTION
PR that would:

- Remove the need to find and provide the `organization_id`, but allow a manual overriding value to be set
- Remove the need to find and provide the `admin_environment_id`, but allow a manual overriding value to be set
- Change the `admin_user_id` to be a list of IDs, that can be found by the user from the `pingone_users` datasource filters (in example)
- Ability to set a manual `license_id` - this for me covers for the issue https://github.com/pingidentity/terraform-provider-pingone/issues/182 but also allows manual license selection if there is more than one of the same name
